### PR TITLE
Handle simpler routesum output

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -6,12 +6,11 @@
   disable-all = true
   enable = [
     "asciicheck",
-    "deadcode",
     "dogsled",
     "errcheck",
     "errorlint",
     "exhaustive",
-    "exhaustivestruct",
+    "exhaustruct",
     "exportloopref",
     "funlen",
     "gochecknoglobals",
@@ -32,13 +31,11 @@
     "prealloc",
     "revive",
     "staticcheck",
-    "structcheck",
     "stylecheck",
     "typecheck",
     "unconvert",
     "unparam",
     "unused",
-    "varcheck",
     "vetshadow",
     "wrapcheck",
   ]

--- a/README.md
+++ b/README.md
@@ -24,22 +24,22 @@ Usage of ./routesum-runner:
         Path to the time binary. (default "/usr/bin/time")
 
 $ ./routesum-runner -input ~/routesum-performance/dshield-intelfeed-ips.txt -input ~/routesum-performance/GeoLite2-Country-Networks.txt -routesum ./routesum-bst -routesum ./routesum-radix -num-runs 10
-Input,Binary,Metric,Amount
-dshield-intelfeed-ips.txt,routesum-bst,To Store Routes - Δ total allocated bytes,44914264
-dshield-intelfeed-ips.txt,routesum-bst,To Store Routes - Δ mallocs,1594243
-dshield-intelfeed-ips.txt,routesum-bst,To Store Routes - Δ frees,468337
+Input,Metric,Binary,Amount
+GeoLite2-ASN-Networks.txt,Num internal nodes,routesum-bst,4622053
+GeoLite2-ASN-Networks.txt,Num leaf nodes,routesum-bst,4622055
+GeoLite2-ASN-Networks.txt,Size of all internal nodes,routesum-bst,463039380
 ...
-dshield-intelfeed-ips.txt,routesum-radix,To Store Routes - Δ total allocated bytes,17896936
-dshield-intelfeed-ips.txt,routesum-radix,To Store Routes - Δ mallocs,583901
-dshield-intelfeed-ips.txt,routesum-radix,To Store Routes - Δ frees,312098
+GeoLite2-ASN-Networks.txt,Num internal nodes,routesum-radix,622053
+GeoLite2-ASN-Networks.txt,Num leaf nodes,routesum-radix,622055
+GeoLite2-ASN-Networks.txt,Size of all internal nodes,routesum-radix,63039380
 ...
-GeoLite2-Country-Networks.txt,routesum-bst,To Store Routes - Δ total allocated bytes,2355023304
-GeoLite2-Country-Networks.txt,routesum-bst,To Store Routes - Δ mallocs,24400781
-GeoLite2-Country-Networks.txt,routesum-bst,To Store Routes - Δ frees,23528854
+GeoLite2-Country-Networks.txt,Num internal nodes,routesum-bst,496323
+GeoLite2-Country-Networks.txt,Num leaf nodes,routesum-bst,496325
+GeoLite2-Country-Networks.txt,Size of all internal nodes,routesum-bst,412266326
 ...
-GeoLite2-Country-Networks.txt,routesum-radix,To Store Routes - Δ total allocated bytes,852038168
-GeoLite2-Country-Networks.txt,routesum-radix,To Store Routes - Δ mallocs,17451592
-GeoLite2-Country-Networks.txt,routesum-radix,To Store Routes - Δ frees,16970186
+GeoLite2-Country-Networks.txt,Num internal nodes,routesum-radix,96323
+GeoLite2-Country-Networks.txt,Num leaf nodes,routesum-radix,96325
+GeoLite2-Country-Networks.txt,Size of all internal nodes,routesum-radix,12266326
 ...
 ```
 

--- a/cmd/routesum-runner/main.go
+++ b/cmd/routesum-runner/main.go
@@ -1,3 +1,4 @@
+// Package main provides a program that creates CSVs of routesum performance data over multiple runs
 package main
 
 import (

--- a/cmd/routesum-runner/main.go
+++ b/cmd/routesum-runner/main.go
@@ -33,7 +33,7 @@ func fatalf(err error) {
 
 func runAllInputsAndBinaries(a *args) error {
 	csvOut := csv.NewWriter(os.Stdout)
-	if err := csvOut.Write([]string{"Input", "Binary", "Metric", "Amount"}); err != nil {
+	if err := csvOut.Write([]string{"Input", "Metric", "Binary", "Amount"}); err != nil {
 		return errors.Wrap(err, "write csv header")
 	}
 
@@ -94,7 +94,7 @@ func runNTimesAndInterpret(
 			return fmt.Errorf("interpret mem stat output: %w", err)
 		}
 		for _, m := range measurements {
-			if err := csvOut.Write([]string{inputBase, rsBinBase, m.metric, m.amount}); err != nil {
+			if err := csvOut.Write([]string{inputBase, m.metric, rsBinBase, m.amount}); err != nil {
 				return errors.Wrap(err, "write csv data line")
 			}
 		}

--- a/cmd/routesum-runner/main.go
+++ b/cmd/routesum-runner/main.go
@@ -63,7 +63,7 @@ func runNTimesAndInterpret(
 	if err != nil {
 		return errors.Wrapf(err, "open %s for reading", inputPath)
 	}
-	defer func() { //nolint: gosec // we're just reading from the file
+	defer func() {
 		if err := inputFile.Close(); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to close input file: %+v\n", err)
 		}


### PR DESCRIPTION
routesum is being updated to output simpler memory usage statistics. As a result, the runner needs to be less sophisticated.